### PR TITLE
Using footmisc to push footnotes to bottom of page

### DIFF
--- a/templates/math.tex
+++ b/templates/math.tex
@@ -392,6 +392,8 @@ $if(classic-title)$
   $endif$
 $endif$
 
+\usepackage[bottom]{footmisc}
+
 \usepackage{tikz}
 \usetikzlibrary{arrows,positioning}
 \usepackage[font=small]{caption}


### PR DESCRIPTION
Since the `math-latex` template is based on Pandoc's default LaTeX template, I'm not sure why the footnotes were ending up in the middle of the page, but using `\usepackage[bottom]{footmisc}` seems to fix it.